### PR TITLE
Added Support for Raspberry Pi Pico

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ConsentiumThingsDalton
 
-**Version:** v0.1.0
+**Version:** v0.1.1
 
 **Description:**
 
@@ -35,3 +35,11 @@ This project is licensed under the MIT License.
 **Contributing:**
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+# Licensing and Credits
+* The [Arduino IDE and ArduinoCore-API](https://arduino.cc) are developed and maintained by the Arduino team. The IDE is licensed under GPL.
+* The [RP2040 GCC-based toolchain](https://github.com/earlephilhower/pico-quick-toolchain) is licensed under under the GPL.
+* The [Pico-SDK](https://github.com/raspberrypi/pico-sdk) is by Raspberry Pi (Trading) Ltd and licensed under the BSD 3-Clause license.
+* The [ESP8266 Libraries] modified from ESP8266 Core Development Team: [GitHub](https://github.com/esp8266/Arduino)
+* The [ESP32 Libraries are part of Espressif Systems]: [Website](https://www.espressif.com/) ESP32 Arduino Core Development Team: [GitHub](https://github.com/espressif/arduino-esp32)
+  

--- a/src/ConsentiumThingsDalton.cpp
+++ b/src/ConsentiumThingsDalton.cpp
@@ -35,7 +35,7 @@ void syncTime(){
 
 void ConsentiumThings::begin() {
   Serial.begin(ESPBAUD);
-  #ifdef ESP32
+  #if defined(ESP32) || defined(ARDUINO_RASPBERRY_PI_PICO_W)
     client.setCACert(consentium_root_ca);
   #elif ESP8266
     syncTime();

--- a/src/ConsentiumThingsDalton.h
+++ b/src/ConsentiumThingsDalton.h
@@ -25,7 +25,18 @@
     #define ADC_IN A0 // A0
 
     #define ADC_VREF_mV    3300.0 // in millivolt
-    #define ADC_RESOLUTION 1024.0     
+    #define ADC_RESOLUTION 1024.0
+#elif ARDUINO_RASPBERRY_PI_PICO_W
+    #include <WiFi.h>
+    #include <HTTPClient.h>
+    #include <WiFiClientSecure.h>
+    #define S_0 6 
+    #define S_1 7
+    #define S_2 8
+    #define S_3 9  
+    #define ADC_IN 34 // ADC Channel 2
+    #define ADC_VREF_mV    3300.0 // in millivolt
+    #define ADC_RESOLUTION 4096.0  
 #endif
 
 #define SELECT_LINES 4


### PR DESCRIPTION
HTTPS POST SUCCESSFULLY , Wifi.h is Common to both Pico and ESP32 and ESP8266